### PR TITLE
Add version to manifest.json

### DIFF
--- a/custom_components/tuya/manifest.json
+++ b/custom_components/tuya/manifest.json
@@ -1,6 +1,7 @@
 {
   "domain": "tuya",
   "name": "Tuya",
+  "version": "2.0.0",
   "codeowners": ["@Tuya", "@zlinoliver", "@frenck"],
   "config_flow": true,
   "dependencies": ["ffmpeg"],


### PR DESCRIPTION
My irrigation pump (Product Category: 
sfkzq) stopped working with the most recent updates and was reporting (unsupported) in the Tuya integration.

I attempted reverting most of the recent commits with no success.   Finally I found your own post about simply adding a version to the manifest.  This has resolved my issue. 

https://github.com/home-assistant/core/issues/72029#issuecomment-1229245445